### PR TITLE
Took out SDL Mixer from makefile and changed c++11 to c++0x

### DIFF
--- a/SDL/Makefile
+++ b/SDL/Makefile
@@ -5,9 +5,9 @@ OBJS = src/Main.cpp src/SongLoader.cpp src/SongPlayer.cpp include/threadClass.hp
 CC = g++
 
 #COMPLIE_FLAGS = additional flags
-COMPILE_FLAGS = -w -g -std=c++11
+COMPILE_FLAGS = -w -g -std=c++0x
 
-LINK_FLAGS = `sdl2-config --cflags` `sdl2-config --libs` `pkg-config opencv --cflags` `pkg-config opencv --libs` -lSDL2_image -lSDL2_ttf -lSDL2_mixer -ltiff -lao -lmpg123 -pthread
+LINK_FLAGS = `sdl2-config --cflags` `sdl2-config --libs` `pkg-config opencv --cflags` `pkg-config opencv --libs` -lSDL2_image -lSDL2_ttf -ltiff -lao -lmpg123 -pthread
 
 
 #OUTPUT_NAME = final name


### PR DESCRIPTION
Taking out SDL Mixer because we don't use it anymore. C++11 was added by accident and should be c++0x.
